### PR TITLE
Complete colorbar=False logic in cnt_helpers.

### DIFF
--- a/pygeode/plot/cnt_helpers.py
+++ b/pygeode/plot/cnt_helpers.py
@@ -313,7 +313,10 @@ def clfdict(cdelt, min=None, mid=0., nf=6, nl=2, ndiv=3, nozero=False, style='di
 
   kwcb = kwargs.pop('colorbar', {})
   cb = dict(ticks = tks)
-  cb.update(kwcb)
+  if kwcb is False:
+    cb = False
+  else:
+    cb.update(kwcb)
 
   if not clr: 
     cmp = pcm.gray
@@ -364,7 +367,10 @@ def log1sdict(cmin, cdelt = 10., nf=6, nl=2, ndiv=5, **kwargs):
 
   kwcb = kwargs.pop('colorbar', {})
   cb = dict(ticks=tks, width=1.4, rl=0.01, rr=0.16, ticklabels = [lfmt(x) for x in tks])
-  cb.update(kwcb)
+  if kwcb is False:
+    cb = False
+  else:
+    cb.update(kwcb)
 
   kwa = dict(clevs = cf,
               clines = cl,
@@ -411,6 +417,10 @@ def log2sdict(cmin, cdelt = 10, nf=6, nl=2, ndiv=3, nozero=False, **kwargs):
   kwcb = kwargs.pop('colorbar', {})
   cb = dict(ticks=tks, width=1.4, rl=0.01, rr=0.16, ticklabels = [lfmt(x) for x in tks])
   cb.update(kwcb)
+  if kwcb is False:
+    cb = False
+  else:
+    cb.update(kwcb)
 
   kwa = dict(clevs = cf,
               clines = cl,

--- a/tests/issues/issue120_test.py
+++ b/tests/issues/issue120_test.py
@@ -8,7 +8,8 @@ ax1 = pyg.showvar(t1.Temp)
 
 ax2 = pyg.showvar(t1.Temp,colorbar=False)
 
-# assming that if there is a second axis, it will be a colorbar
+# assuming that if there is a second axis, it will be a colorbar
+# and axes list will have non-zero length
 assert len(ax1.axes)==2
 
 assert len(ax2.axes)==0

--- a/tests/issues/issue120_test.py
+++ b/tests/issues/issue120_test.py
@@ -1,0 +1,15 @@
+from pygeode.tutorial import t1
+imoprt pylab as pyl
+
+pyl.ioff()
+
+# default behaviour
+ax1 = pyg.showvar(t1.Temp)
+
+ax2 = pyg.showvar(t1.Temp,colorbar=False)
+
+# assming that if there is a second axis, it will be a colorbar
+assert len(ax1.axes)==2
+
+assert len(ax2.axes)==0
+


### PR DESCRIPTION
Related to issue #120. There are a few other ways to fix this, but I think this is the simplest solution that keeps functionality. Other possibilities:
1) Remove the docstring statement that ```colorbar=False``` is an argument option.
2) Place the value into the colorbar dict as soon as possible so that colorbar remains a dict throughout.
There's probably a few other ways to do this.

I tested in ipython that the default behaviour (no colorbar argument returning a colorbar) and the intended behaviour (```colorbar=False``` leading to no colorbar) are now as expected. 

I've also devised an issue120_test.py file. Because it's testing matplotlib figure output, the test is a bit contrived. It's checking the number of axes returned from showvar in each case. Would that test file be worth submitting too?
