### PR TITLE
Relabelled r2 and added r to pyg.correlate

### DIFF
--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -35,7 +35,7 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
     through ``ds.r2``).
 
     * 'r': The r value of the correlation coefficient :math:`\rho_{XY}`
-    * 'r2': The correlation coefficient :math:`\rho_{XY}`
+    * 'r2': The coefficient of determination :math:`\rho^2_{XY}`
     * 'p':  The p-value; see notes.
 
   Notes

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -127,7 +127,6 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
   # Compute correlation coefficient, t-statistic, p-value
   den = np.zeros(oview.shape, 'd')
   rho = np.zeros(oview.shape, 'd')
-  rho2 = np.zeros(oview.shape, 'd')
 
   den[imsk] = np.sqrt((xx*yy)[imsk])
   dmsk = (den > 0.)

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -167,7 +167,7 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
     from warnings import warn
     warn ("r2 now returns the correct value as opposed to r")
     r2 = Var(oaxes, values=rho2, name='r2')
-    r2.atts['longname'] = 'Correlation coefficient r^2 between %s and %s' % (xn, yn)
+    r2.atts['longname'] = 'Coefficient of determination r^2 between %s and %s' % (xn, yn)
     rvs.append(r2)
 
   if 'p' in output:

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -7,7 +7,7 @@ from scipy.stats import norm, t as tdist
 
 def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
 # {{{
-  r'''Computes correlation between variables X and Y.
+  r'''Computes Pearson correlation coefficient between variables X and Y.
 
   Parameters
   ==========

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -5,7 +5,7 @@ __all__ = ('correlate', 'regress', 'multiple_regress', 'difference', 'paired_dif
 import numpy as np
 from scipy.stats import norm, t as tdist
 
-def correlate(X, Y, axes=None, output = 'r,r2,p', pbar=None):
+def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
 # {{{
   r'''Computes correlation between variables X and Y.
 
@@ -21,7 +21,7 @@ def correlate(X, Y, axes=None, output = 'r,r2,p', pbar=None):
   output : string, optional
     A string determining which parameters are returned; see list of possible outputs
     in the Returns section. The specifications must be separated by a comma. Defaults
-    to 'r,r2,p'.
+    to 'r,p'.
 
   pbar : progress bar, optional
     A progress bar object. If nothing is provided, a progress bar will be displayed
@@ -51,6 +51,7 @@ def correlate(X, Y, axes=None, output = 'r,r2,p', pbar=None):
   from pygeode.view import View
 
   # Split output request now
+  # Default output is 'r,p' so as not to break existing scripts
   ovars = ['r', 'r2', 'p']
   output = [o for o in output.split(',') if o in ovars]
   if len(output) < 1: raise ValueError('No valid outputs are requested from correlation. Possible outputs are %s.' % str(ovars))
@@ -167,6 +168,8 @@ def correlate(X, Y, axes=None, output = 'r,r2,p', pbar=None):
     rvs.append(r)
 
   if 'r2' in output:
+    from warnings import warn
+    warn ("r2 now returns the correct value as opposed to r")
     r2 = Var(oaxes, values=rho2, name='r2')
     r2.atts['longname'] = 'Correlation coefficient r^2 between %s and %s' % (xn, yn)
     rvs.append(r2)

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -166,7 +166,7 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
   if 'r2' in output:
     from warnings import warn
     warn ("r2 now returns the correct value as opposed to r")
-    r2 = Var(oaxes, values=rho2, name='r2')
+    r2 = Var(oaxes, values=rho**2, name='r2')
     r2.atts['longname'] = 'Coefficient of determination r^2 between %s and %s' % (xn, yn)
     rvs.append(r2)
 

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -147,7 +147,6 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
 
   p[~imsk] = np.nan
   rho[~imsk] = np.nan
-  rho2[~imsk] = np.nan
 
   p[~dmsk] = np.nan
   rho[~dmsk] = np.nan

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -149,7 +149,6 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
 
   p[~dmsk] = np.nan
   rho[~dmsk] = np.nan
-  rho2[~dmsk] = np.nan
 
   pbar.update(100)
 

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -34,7 +34,7 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
     is the returned dataset, the correlation coefficient can be obtained
     through ``ds.r2``).
 
-    * 'r': The r value of the correlation coefficient :math:`\rho_{XY}`
+    * 'r': The Pearson correlation coefficient :math:`\rho_{XY}`
     * 'r2': The coefficient of determination :math:`\rho^2_{XY}`
     * 'p':  The p-value; see notes.
 

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -5,7 +5,7 @@ __all__ = ('correlate', 'regress', 'multiple_regress', 'difference', 'paired_dif
 import numpy as np
 from scipy.stats import norm, t as tdist
 
-def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
+def correlate(X, Y, axes=None, output = 'r,r2,p', pbar=None):
 # {{{
   r'''Computes correlation between variables X and Y.
 
@@ -21,7 +21,7 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
   output : string, optional
     A string determining which parameters are returned; see list of possible outputs
     in the Returns section. The specifications must be separated by a comma. Defaults
-    to 'r2,p'.
+    to 'r,r2,p'.
 
   pbar : progress bar, optional
     A progress bar object. If nothing is provided, a progress bar will be displayed
@@ -34,6 +34,7 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
     is the returned dataset, the correlation coefficient can be obtained
     through ``ds.r2``).
 
+    * 'r': The r value of the correlation coefficient :math:`\rho_{XY}`
     * 'r2': The correlation coefficient :math:`\rho_{XY}`
     * 'p':  The p-value; see notes.
 
@@ -50,7 +51,7 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
   from pygeode.view import View
 
   # Split output request now
-  ovars = ['r2', 'p']
+  ovars = ['r', 'r2', 'p']
   output = [o for o in output.split(',') if o in ovars]
   if len(output) < 1: raise ValueError('No valid outputs are requested from correlation. Possible outputs are %s.' % str(ovars))
 
@@ -125,11 +126,13 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
   # Compute correlation coefficient, t-statistic, p-value
   den = np.zeros(oview.shape, 'd')
   rho = np.zeros(oview.shape, 'd')
+  rho2 = np.zeros(oview.shape, 'd')
 
   den[imsk] = np.sqrt((xx*yy)[imsk])
   dmsk = (den > 0.)
 
   rho[dmsk] = xy[dmsk] / np.sqrt(xx*yy)[dmsk]
+  rho2[dmsk] = xy[dmsk]**2 / (xx*yy[dmsk])
 
   den = 1 - rho**2
   # Saturate the denominator (when correlation is perfect) to avoid div by zero warnings
@@ -144,9 +147,11 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
 
   p[~imsk] = np.nan
   rho[~imsk] = np.nan
+  rho2[~imsk] = np.nan
 
   p[~dmsk] = np.nan
   rho[~dmsk] = np.nan
+  rho2[~dmsk] = np.nan
 
   pbar.update(100)
 
@@ -156,9 +161,14 @@ def correlate(X, Y, axes=None, output = 'r2,p', pbar=None):
 
   rvs = []
 
+  if 'r' in output:
+    r = Var(oaxes, values=rho, name='r')
+    r.atts['longname'] = 'Correlation coefficient r between %s and %s' % (xn, yn)
+    rvs.append(r)
+
   if 'r2' in output:
-    r2 = Var(oaxes, values=rho, name='r2')
-    r2.atts['longname'] = 'Correlation coefficient between %s and %s' % (xn, yn)
+    r2 = Var(oaxes, values=rho2, name='r2')
+    r2.atts['longname'] = 'Correlation coefficient r^2 between %s and %s' % (xn, yn)
     rvs.append(r2)
 
   if 'p' in output:

--- a/pygeode/stats.py
+++ b/pygeode/stats.py
@@ -132,7 +132,6 @@ def correlate(X, Y, axes=None, output = 'r,p', pbar=None):
   dmsk = (den > 0.)
 
   rho[dmsk] = xy[dmsk] / np.sqrt(xx*yy)[dmsk]
-  rho2[dmsk] = xy[dmsk]**2 / (xx*yy[dmsk])
 
   den = 1 - rho**2
   # Saturate the denominator (when correlation is perfect) to avoid div by zero warnings


### PR DESCRIPTION
Modified for consistency with pyg.regress and von Storch and Zweirs definition of &rho;<sub>xy</sub>.

pyg.correlate returns `r2` but this should be `r`. This has been fixed and `r2` has been added.