### PR TITLE
Implement cmap_from_cdict

### DIFF
--- a/pygeode/plot/__init__.py
+++ b/pygeode/plot/__init__.py
@@ -17,6 +17,6 @@ from pygeode.plot.cnt_helpers import *
 from pygeode.plot.cnt_helpers import __all__ as chelp_all
 __all__.extend(chelp_all)
 
-from pygeode.plot.cm import cmap_from_hues
+from pygeode.plot.cm import cmap_from_hues, cmap_from_cdict
 from pygeode.plot.cm import __all__ as cm_all
 __all__.extend(cm_all)

--- a/pygeode/plot/cm.py
+++ b/pygeode/plot/cm.py
@@ -68,6 +68,8 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
   Each `value` can be either a single color, or two colors as an array-like object so that
   matplotlib can apply a non-linear transition of color at each key.
 
+  It's also possible to specify the "over" and "under" colors in cdict for the colormap.
+
   See Examples.
 
   Parameters
@@ -101,10 +103,26 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
   ...   1: [1, 1, 1]
   ... }
   >>> cmap = cmap_from_cdict(cdict)
+
+  If desired, we can also specify under and over for the colormap.
+
+  >>> from pygeode.plot.cm import cmap_from_cdict
+  >>> cdict = {
+  ...   'over': [0, 0, 0],
+  ...   'under': [0, 0, 0],
+  ...   -1: [1, 1, 1],
+  ...   -0.1: ([0, 0, 0], [1, 1, 1]),
+  ...   0.1: ([1, 1, 1], [0, 0, 0]),
+  ...   1: [1, 1, 1]
+  ... }
+  >>> cmap = cmap_from_cdict(cdict)
   """
   import matplotlib.colors as mcolors
   import math
   import numpy as np
+
+  over = cdict.pop('over', None)
+  under = cdict.pop('under', None)
 
   lastk = -math.inf
   mpl_cdict = dict(red=[], green=[], blue=[], alpha=[])
@@ -137,6 +155,12 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
     lastk = k
 
   cmap = mcolors.LinearSegmentedColormap('cmap', mpl_cdict)
+
+  if over is not None:
+    cmap.set_over(over)
+  if under is not None:
+    cmap.set_under(under)
+
   return cmap
 
 def build_cmap(stops): 

--- a/pygeode/plot/cm.py
+++ b/pygeode/plot/cm.py
@@ -79,10 +79,11 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
 
   colorspace : str
     Defines the colorspace of the values in `cdict` such that the values can be transformed
-    into the RGBA format. Valid options are "rgb", "rgba", "hsv", and "hex".
+    into the RGBA format. Valid options are "rgb" or "hex".
 
-    Note that for "rgb", "rgba" and "hsv", each value in the dictionary should be a list of
-    floats within [0, 1] (or a tuple of such lists).
+    Note that "rgb" supports a variety of equivalent formats. For example,
+    [0, 0, 0] (black in "rgb"), [0, 0, 0, 0.5] (black, with the alpha value set to 0.5),
+    and "#000000" (black as a hex string) are all valid values for ``cdict``. See Examples.
 
     Defaults to "rgb".
 
@@ -98,8 +99,8 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
   >>> from pygeode.plot.cm import cmap_from_cdict
   >>> cdict = {
   ...   -1: [1, 1, 1],
-  ...   -0.1: ([0, 0, 0], [1, 1, 1]),
-  ...   0.1: ([1, 1, 1], [0, 0, 0]),
+  ...   -0.1: ([0, 0, 0, 1], [1, 1, 1]),
+  ...   0.1: ([1, 1, 1], "#000000"),
   ...   1: [1, 1, 1]
   ... }
   >>> cmap = cmap_from_cdict(cdict)
@@ -129,13 +130,13 @@ def cmap_from_cdict(cdict, colorspace='rgb'):
   keys = list(cdict.keys())
   norm = mcolors.Normalize(vmin=keys[0], vmax=keys[-1])
 
-  if colorspace in ['rgb', 'rgba', 'hex']:
+  if colorspace == 'rgb':
     convert_color = lambda v: mcolors.to_rgba(v)
   elif colorspace == 'hsv':
     convert_color = lambda v: mcolors.to_rgba(mcolors.hsv_to_rgb(v))
   else:
     raise ValueError(
-      f'Colorspace "{colorspace}" must be one of "rgb", "rgba", "hsv", or "hex".')
+      f'Colorspace "{colorspace}" must be "rgb" or "hsv".')
 
   for k, v in cdict.items():
     if k < lastk:

--- a/pygeode/plot/cm.py
+++ b/pygeode/plot/cm.py
@@ -60,6 +60,85 @@ def cmap_from_hues(hues=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], sat=[0.2, 0.9], rval=[0.
   return build_cmap(stops)
 # }}}
 
+def cmap_from_cdict(cdict, colorspace='rgb'):
+  """
+  Constructs a colormap based on ``cdict``.
+
+  ``cdict`` is a python dictionary where each `value` specifies the color code for each `key`.
+  Each `value` can be either a single color, or two colors as an array-like object so that
+  matplotlib can apply a non-linear transition of color at each key.
+
+  See Examples.
+
+  Parameters
+  ----------
+  cdict : dict
+    The color dictionary.
+
+  colorspace : str
+    Defines the colorspace of the values in `cdict` such that the values can be transformed
+    into the RGBA format. Valid options are "rgb", "rgba", "hsv", and "hex".
+
+    Note that for "rgb", "rgba" and "hsv", each value in the dictionary should be a list of
+    floats within [0, 1] (or a tuple of such lists).
+
+    Defaults to "rgb".
+
+  Returns
+  -------
+  matplotlib.colors.LinearSegmentedColormap
+
+  Examples
+  --------
+  The `cdict` below defines a colormap that changes from white to black in [-1, -0.1],
+  stays white in [-0.1, 0.1], and transitions from white to black in [0.1, 1].
+
+  >>> from pygeode.plot.cm import cmap_from_cdict
+  >>> cdict = {
+  ...   -1: [1, 1, 1],
+  ...   -0.1: ([0, 0, 0], [1, 1, 1]),
+  ...   0.1: ([1, 1, 1], [0, 0, 0]),
+  ...   1: [1, 1, 1]
+  ... }
+  >>> cmap = cmap_from_cdict(cdict)
+  """
+  import matplotlib.colors as mcolors
+  import math
+  import numpy as np
+
+  lastk = -math.inf
+  mpl_cdict = dict(red=[], green=[], blue=[], alpha=[])
+  keys = list(cdict.keys())
+  norm = mcolors.Normalize(vmin=keys[0], vmax=keys[-1])
+
+  if colorspace in ['rgb', 'rgba', 'hex']:
+    convert_color = lambda v: mcolors.to_rgba(v)
+  elif colorspace == 'hsv':
+    convert_color = lambda v: mcolors.to_rgba(mcolors.hsv_to_rgb(v))
+  else:
+    raise ValueError(
+      f'Colorspace "{colorspace}" must be one of "rgb", "rgba", "hsv", or "hex".')
+
+  for k, v in cdict.items():
+    if k < lastk:
+      raise ValueError('The keys for "cdict" should increase monotonously.')
+
+    if hasattr(v, '__len__') and len(v) == 2:
+      r1, g1, b1, a1 = convert_color(v[0])
+      r2, g2, b2, a2 = convert_color(v[1])
+    else:
+      r1, g1, b1, a1 = r2, g2, b2, a2 = convert_color(v)
+
+    mpl_cdict['red'].append([norm(k), r1, r2])
+    mpl_cdict['green'].append([norm(k), g1, g2])
+    mpl_cdict['blue'].append([norm(k), b1, b2])
+    mpl_cdict['alpha'].append([norm(k), a1, a2])
+
+    lastk = k
+
+  cmap = mcolors.LinearSegmentedColormap('cmap', mpl_cdict)
+  return cmap
+
 def build_cmap(stops): 
 # {{{ 
   from matplotlib.colors import LinearSegmentedColormap
@@ -212,4 +291,4 @@ def read_config():
 # Read in configuration file on import
 read_config()
 
-__all__ = ['cmap_from_hues']
+__all__ = ['cmap_from_hues', 'cmap_from_cdict']


### PR DESCRIPTION
This PR implements a function that creates a function based on a color dictionary. Each value in the dictionary specifies the color code for each key. Each value can be either a single color or two colors as an array-like object so that matplotlib can apply a non-linear transition of color at each key. Valid options for the keys are "rgb", "rgba", "hsv", and "hex". Below is an example:

```
from pygeode.plot.cm import cmap_from_cdict
cdict = {
    -1: [1, 1, 1],
    -0.1: ([0, 0, 0], [1, 1, 1]),
    0.1: ([1, 1, 1], [0, 0, 0]),
    1: [1, 1, 1]
}
cmap = cmap_from_cdict(cdict)
```

This example defines a colormap that changes from white to black in [-1, -0.1], stays white in [-0.1, 0.1], and transitions from white to black in [0.1, 1].